### PR TITLE
Added onClose prop to CookieAcceptance.tsx

### DIFF
--- a/src/Components/CookieAcceptance/CookieAcceptance.tsx
+++ b/src/Components/CookieAcceptance/CookieAcceptance.tsx
@@ -25,6 +25,7 @@ const CookieAcceptance = ({
   appName,
   settings,
   onConfirm,
+  onClose
 }: CookieAcceptanceProps) => {
   const {
     visible,
@@ -111,8 +112,10 @@ const CookieAcceptance = ({
     ) {
       setVisible(false);
       setExpanded(false);
+      onClose();
     } else {
       setExpanded(false);
+      onClose();
     }
   };
 

--- a/src/Components/CookieAcceptance/CookieAcceptance.types.ts
+++ b/src/Components/CookieAcceptance/CookieAcceptance.types.ts
@@ -8,6 +8,7 @@ export interface CookieAcceptanceProps {
     image?: string;
     injectScript: () => void;
     onConfirm: () => void;
+    onClose: () => void;
     cookies: Array<CookieTypes>;
     appName: string;
     className: string;


### PR DESCRIPTION
[Part of a fix for HFE-2783](https://myclevergroup.atlassian.net/browse/HFE-2783)

At the moment when a user clicks 'Close' on the cookie acceptance modal, it sets 'visible' to false within the package so that the modal disappear. However the state that we track within HulerHub 'cookieSettingsActive' is still set to 'true' because we have not made a connection between the cookie package and HulerHub.

This PR will allow us to pass a prop through to the cookie package, similar to how 'onConfirm' works and allow us to change the 'cookieSettingsActive' state in HulerHub at the same time.

Once this PR has been merged, the package will need building and then 'huler-client' will need updating for the newest version number.